### PR TITLE
Initialize Dockerfile, add json logging option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM registry.opensuse.org/opensuse/tumbleweed:latest AS builder
+RUN zypper --non-interactive install -y go tar gzip
+WORKDIR /build
+COPY . .
+RUN go build -o osc-mcp .
+
+FROM registry.opensuse.org/opensuse/tumbleweed:latest
+
+# Install osc and build tools
+RUN zypper --non-interactive install -y \
+    osc \
+    build \
+    ca-certificates \
+    && zypper clean -a
+
+COPY --from=builder /build/osc-mcp /usr/local/bin/
+
+# Create workspace directory
+WORKDIR /workspace
+
+# Environment variables for authentication
+ENV OSC_MCP_API="api.opensuse.org"
+ENV OSC_MCP_USER=""
+ENV OSC_MCP_PASSWORD=""
+ENV OSC_MCP_WORKDIR="/workspace"
+
+EXPOSE 8666
+
+ENTRYPOINT ["/usr/local/bin/osc-mcp"]
+CMD ["--http", "0.0.0.0:8666", "--workdir", "/workspace", "--clean-workdir", "-v"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,62 @@ Create a configuration file `~/.mcphost.yml` and add the following lines to add 
 This program can be used to check the available tools.
 
 
+# Logging
+
+The MCP server includes comprehensive logging to help monitor operations and troubleshoot issues.
+
+## Log Levels
+
+Use the following flags to control logging verbosity:
+
+- **Default (Warn)**: Only warnings and errors are logged
+- **`-v` or `--verbose`**: Enable info-level logging for important operational events
+- **`-d` or `--debug`**: Enable debug-level logging for detailed diagnostic information
+
+## Log Output Options
+
+### Standard Output (stderr)
+By default, logs are written to stderr:
+```bash
+go run osc-mcp.go -v
+```
+
+### File Output
+Direct logs to a file for persistent logging:
+```bash
+go run osc-mcp.go -v --logfile /var/log/osc-mcp.log
+```
+
+### JSON Format
+For machine-readable logs (useful for log aggregation systems):
+```bash
+go run osc-mcp.go -v --log-json
+```
+
+JSON logging can be combined with file output:
+```bash
+go run osc-mcp.go -v --log-json --logfile /var/log/osc-mcp.json
+```
+
+## What Gets Logged
+
+- **Info level** (`-v`): Major operations like builds, commits, checkouts, file uploads, and their durations
+- **Debug level** (`-d`): API requests/responses, command execution details, file operations, and internal state
+- **Warn level** (default): Non-fatal issues like missing configs or failed progress notifications
+- **Error level** (always): Fatal errors with full context
+
+## Example Usage
+
+Monitor build operations with timing information:
+```bash
+go run osc-mcp.go -v --http localhost:8666 --workdir /tmp/mcp/osc-mcp/
+```
+
+Full debugging with JSON output to a file:
+```bash
+go run osc-mcp.go -d --log-json --logfile debug.json --http localhost:8666
+```
+
 # Other functionality
 
 For all options use

--- a/internal/pkg/osc/checkout.go
+++ b/internal/pkg/osc/checkout.go
@@ -44,13 +44,16 @@ func (cred *OSCCredentials) CheckoutBundle(ctx context.Context, req *mcp.CallToo
 	var out bytes.Buffer
 	oscCmd.Stdout = &out
 	oscCmd.Stderr = &out
+	slog.Info("Checking out bundle", "project", params.Project, "package", params.Package)
 	if err := oscCmd.Run(); err != nil {
 		slog.Error("failed to run osc checkout", slog.String("command", oscCmd.String()), slog.String("output", out.String()))
 		return nil, CheckoutPackageResult{}, fmt.Errorf("failed to run osc checkout command `%s`: %w\nOutput:\n%s", oscCmd.String(), err, out.String())
 	}
 
+	checkoutPath := path.Join(cred.TempDir, params.Project, params.Package)
+	slog.Info("Bundle checked out successfully", "path", checkoutPath)
 	return nil, CheckoutPackageResult{
-		Path:        path.Join(cred.TempDir, params.Project, params.Package),
+		Path:        checkoutPath,
 		PackageName: params.Package,
 		ProjectName: params.Project,
 	}, nil


### PR DESCRIPTION
## Summary
This PR introduces several enhancements to the osc-mcp server focusing on Docker deployment, improved buildlog functionality, and better logging options.

**Note**: The Docker container is designed for running the osc-mcp server only. It does not support building packages within the container itself.

## Changes

### Docker Support
- **New Dockerfile**: Multi-stage build using openSUSE Tumbleweed as base image
  - Builder stage compiles the Go binary
  - Runtime stage includes osc, build tools, and ca-certificates
  - Exposed on port 8666 with configurable environment variables for authentication
  - Default workdir at `/workspace` with auto-cleanup option
  - **Container is for server deployment only, not for package building**

### Buildlog Enhancements
- **Flavor Support**: Added flavor parameter support for buildlogs to handle multi-flavor packages
- **Log Filtering**: Implemented log line limiting and filtering capabilities to reduce token usage
- **Time Removal**: Stripped timestamps from buildlog output to conserve tokens in LLM contexts
- **Better Error Handling**: Improved error reporting and log parsing

### Code Improvements
- **JSON Logging Option**: Added JSON logging format support for structured logging
- **OSC Status Check**: Added pre-commit status check to ensure clean working directory
- **Project Meta Enhancements**: Improved project metadata handling with better error checking
- **Documentation**: Updated README with Docker usage instructions and deployment examples

## Files Changed
- `Dockerfile` (new): Container build configuration
- `README.md`: Added Docker documentation
- `internal/pkg/buildlog/buildlog.go`: Enhanced filtering and parsing
- `internal/pkg/osc/buildlog.go`: Added flavor support, line limiting, timestamp removal
- `internal/pkg/osc/commit.go`: Added status check before commit
- `internal/pkg/osc/project_meta.go`: Improved metadata handling
- `osc-mcp.go`: Added JSON logging flag

## Testing
- Tested Docker build and deployment
- Verified buildlog filtering and flavor support
- Confirmed JSON logging output format