### PR TITLE
Containerization fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ WORKDIR /workspace
 ENV OSC_MCP_API="api.opensuse.org"
 ENV OSC_MCP_USER=""
 ENV OSC_MCP_PASSWORD=""
+ENV OSC_MCP_PASSWORD_FILE=
 ENV OSC_MCP_WORKDIR="/workspace"
+ENV OSC_MCP_HTTP=":8666"
 
 EXPOSE 8666
 
 ENTRYPOINT ["/usr/local/bin/osc-mcp"]
-CMD ["--http", "0.0.0.0:8666", "--workdir", "/workspace", "--clean-workdir", "-v"]
+CMD [ "--clean-workdir", "-v"]

--- a/Dockerfile.obs
+++ b/Dockerfile.obs
@@ -1,0 +1,34 @@
+#!BuildTag: mcp-server-osc:%PKG_VERSION%.%GIT_OFFSET%.%RELEASE% mcp-server-osc:%PKG_VERSION%.%GIT_OFFSET% mcp-server-osc:%PKG_VERSION% mcp-server-osc
+FROM opensuse/tumbleweed:latest
+
+# labelprefix=org.opensuse.mcp-server-osc
+LABEL org.opencontainers.image.title="MCP Server for OBS"
+LABEL org.opencontainers.image.description="MCP Server Container for the Open Build Service %PKG_VERSION%.%GIT_OFFSET%"
+LABEL org.opensuse.version="%PKG_VERSION%.%GIT_OFFSET%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+LABEL org.opensuse.reference="registry.opensuse.org/science/machinelearning/mcp/mcp-server-osc:%PKG_VERSION%.%GIT_OFFSET%"
+# endlabelprefix
+
+# Install the MCP server, osc, and build tools
+RUN zypper --non-interactive install -y \
+    mcp-server-osc \
+    osc \
+    build \
+    ca-certificates \
+    && zypper clean -a
+
+# Create workspace directory
+WORKDIR /workspace
+
+# Environment variables for authentication
+ENV OSC_MCP_API="api.opensuse.org"
+ENV OSC_MCP_USER=""
+ENV OSC_MCP_PASSWORD=""
+ENV OSC_MCP_PASSWORD_FILE=""
+ENV OSC_MCP_HTTP=":8666"
+
+EXPOSE 8666
+
+ENTRYPOINT ["/usr/bin/mcp-server-osc"]
+CMD ["--workdir", "/workspace", "--clean-workdir", "-v"]

--- a/internal/pkg/osc/osc.go
+++ b/internal/pkg/osc/osc.go
@@ -120,7 +120,20 @@ func GetCredentials() (OSCCredentials, error) {
 	}
 	if viper.IsSet("password") {
 		pass = viper.GetString("password")
+	} else if viper.IsSet("password-file") {
+		path := viper.GetString("password-file")
+		pass_bytes, err := os.ReadFile(path)
+		if err != nil {
+			return creds, fmt.Errorf("%w", err)
+		}
+
+		pass = strings.TrimRight(string(pass_bytes), "\r\n")
+
+		if pass == "" {
+			return creds, fmt.Errorf("empty password file")
+		}
 	}
+
 	if pass != "" {
 		if user == "" {
 			return creds, fmt.Errorf("user not set for apiurl %s in .oscrc", creds.Apiaddr)

--- a/osc-mcp.go
+++ b/osc-mcp.go
@@ -35,6 +35,7 @@ func main() {
 	pflag.String("user", "", "OBS username")
 	pflag.String("email", "", "user's email address")
 	pflag.String("password", "", "OBS password")
+	pflag.String("password-file", "", "OBS password in specified file")
 	pflag.Bool("print-creds", false, "Just print the retrieved credentials and exit")
 	pflag.Bool("clean-workdir", false, "Cleans the workdir before usage")
 	pflag.String("logfile", "", "if set, log to this file instead of stderr")


### PR DESCRIPTION
These two commits allow osc-mcp to be more usable in a containerized environment. I personally use Aeon as my desktop and want to avoid installing the package itself on the system. These two commits allow me to run it as a container using secrets.